### PR TITLE
Migrate to AWS_ENDPOINT_URL

### DIFF
--- a/shipment-picture-lambda-validator/src/main/java/dev/ancaghenade/shipmentpicturelambdavalidator/S3ClientHelper.java
+++ b/shipment-picture-lambda-validator/src/main/java/dev/ancaghenade/shipmentpicturelambdavalidator/S3ClientHelper.java
@@ -7,15 +7,15 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3ClientHelper {
 
-  private static final String LOCALSTACK_HOSTNAME = System.getenv("LOCALSTACK_HOSTNAME");
+  private static final String AWS_ENDPOINT_URL = System.getenv("AWS_ENDPOINT_URL");
 
   public static S3Client getS3Client() throws IOException {
 
     var clientBuilder = S3Client.builder();
-    if (Objects.nonNull(LOCALSTACK_HOSTNAME)) {
+    if (Objects.nonNull(AWS_ENDPOINT_URL)) {
       return clientBuilder
           .region(Location.REGION.getRegion())
-          .endpointOverride(URI.create(String.format("http://%s:4566", LOCALSTACK_HOSTNAME)))
+          .endpointOverride(URI.create(AWS_ENDPOINT_URL))
           .forcePathStyle(true)
           .build();
     } else {

--- a/shipment-picture-lambda-validator/src/main/java/dev/ancaghenade/shipmentpicturelambdavalidator/SNSClientHelper.java
+++ b/shipment-picture-lambda-validator/src/main/java/dev/ancaghenade/shipmentpicturelambdavalidator/SNSClientHelper.java
@@ -6,20 +6,20 @@ import software.amazon.awssdk.services.sns.SnsClient;
 
 public class SNSClientHelper {
 
-  private static final String LOCALSTACK_HOSTNAME = System.getenv("LOCALSTACK_HOSTNAME");
+  private static final String AWS_ENDPOINT_URL = System.getenv("AWS_ENDPOINT_URL");
   private static String snsTopicArn;
 
   public static SnsClient getSnsClient() {
 
     var clientBuilder = SnsClient.builder();
 
-    if (Objects.nonNull(LOCALSTACK_HOSTNAME)) {
+    if (Objects.nonNull(AWS_ENDPOINT_URL)) {
       snsTopicArn = String.format("arn:aws:sns:%s:000000000000:update_shipment_picture_topic",
           Location.REGION.getRegion());
 
       return clientBuilder
           .region(Location.REGION.getRegion())
-          .endpointOverride(URI.create(String.format("http://%s:4566", LOCALSTACK_HOSTNAME)))
+          .endpointOverride(URI.create(AWS_ENDPOINT_URL))
           .build();
     } else {
       snsTopicArn = String.format("arn:aws:sns:%s:%s:update_shipment_picture_topic",


### PR DESCRIPTION
Adopt `AWS_ENDPOINT_URL` as the official endpoint variable introduced by AWS.

See https://docs.localstack.cloud/user-guide/tools/transparent-endpoint-injection/

/cc repo maintainer @tinyg210 

## Suggested Follow-Up

It would be better to inject the SNS topic ARN through IaC rather than hardcoding it in the application code.