### PR TITLE
Bump TF provider versions and update deprecated resources

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,6 +1,7 @@
 locals {
+  aws_region = "us-east-1"
   json_data  = file("./data.json")
   tf_data    = jsondecode(local.json_data)
-  sns_topic_arn_prod = "arn:aws:sns:${var.aws_region}:${var.account_id}:${var.sns_topic_name}"
-  sns_topic_arn_dev = "arn:aws:sns:${var.aws_region}:000000000000:${var.sns_topic_name}"
+  sns_topic_arn_prod = "arn:aws:sns:${local.aws_region}:${var.account_id}:${var.sns_topic_name}"
+  sns_topic_arn_dev = "arn:aws:sns:${local.aws_region}:000000000000:${var.sns_topic_name}"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = local.aws_region
 }
 
 provider "random" {
@@ -22,11 +22,6 @@ provider "random" {
 resource "random_pet" "random_name" {
   length    = 2
   separator = "-"
-}
-
-variable "aws_region" {
-  description = "AWS region"
-  default     = "us-east-1"
 }
 
 variable "account_id" {
@@ -85,10 +80,10 @@ resource "aws_s3_bucket" "lambda_code_bucket" {
 }
 
 # Lambda source code
-resource "aws_s3_bucket_object" "lambda_code" {
-  source = "../shipment-picture-lambda-validator/target/shipment-picture-lambda-validator.jar"
+resource "aws_s3_object" "lambda_code" {
   bucket = aws_s3_bucket.lambda_code_bucket.id
   key    = "shipment-picture-lambda-validator.jar"
+  source = "../shipment-picture-lambda-validator/target/shipment-picture-lambda-validator.jar"
 }
 
 # Lambda definition
@@ -98,7 +93,7 @@ resource "aws_lambda_function" "shipment_picture_lambda_validator" {
   runtime       = "java17"
   role          = aws_iam_role.lambda_exec.arn
   s3_bucket     = aws_s3_bucket.lambda_code_bucket.id
-  s3_key        = aws_s3_bucket_object.lambda_code.key
+  s3_key        = aws_s3_object.lambda_code.key
   memory_size   = 512
   timeout       = 60
   environment {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,16 +2,21 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 5.31.0"
+      version = "~> 5.59.0"
+    }
+
+    random = {
+      source = "hashicorp/random"
+      version = "~> 3.6.2"
     }
   }
 }
+
 provider "aws" {
   region = "us-east-1"
 }
 
 provider "random" {
-  version = "3.1.0"
 }
 
 resource "random_pet" "random_name" {


### PR DESCRIPTION
There are 3 changes here:

1. updated aws & random provider versions
2. removed `aws_region` variable to `locals.tf` and where it was referenced
3. updated deprecated `aws_s3_bucket_object` to `aws_s3_object`