### PR TITLE
ci: stabilize testcontainers step for scheduled workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,25 +81,18 @@ jobs:
         run: |
           localstack logs
 
-      - name: Ensure Docker is available for Testcontainers
+      - name: Stop LocalStack
         run: |
-          sudo systemctl start docker || true
-          docker version
-          docker info
+          localstack stop
 
       - name: Run Testcontainers tests
         env:
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
           AWS_REGION: us-east-1
-          DOCKER_HOST: unix:///var/run/docker.sock
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           mvn test -Dtest=dev.ancaghenade.shipmentlistdemo.integrationtests.ShipmentServiceIntegrationTest
-
-      - name: Stop LocalStack
-        if: always()
-        run: |
-          localstack stop
 
       - name: Send a Slack notification
         if: failure() || github.event_name != 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,17 +81,25 @@ jobs:
         run: |
           localstack logs
 
-      - name: Stop LocalStack
+      - name: Ensure Docker is available for Testcontainers
         run: |
-          localstack stop
+          sudo systemctl start docker || true
+          docker version
+          docker info
 
       - name: Run Testcontainers tests
         env:
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
           AWS_REGION: us-east-1
+          DOCKER_HOST: unix:///var/run/docker.sock
         run: |
           mvn test -Dtest=dev.ancaghenade.shipmentlistdemo.integrationtests.ShipmentServiceIntegrationTest
+
+      - name: Stop LocalStack
+        if: always()
+        run: |
+          localstack stop
 
       - name: Send a Slack notification
         if: failure() || github.event_name != 'pull_request'

--- a/src/test/java/dev/ancaghenade/shipmentlistdemo/integrationtests/LocalStackSetupConfigurations.java
+++ b/src/test/java/dev/ancaghenade/shipmentlistdemo/integrationtests/LocalStackSetupConfigurations.java
@@ -65,11 +65,14 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 @Testcontainers
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 public class LocalStackSetupConfigurations {
+  private static final String LOCALSTACK_AUTH_TOKEN = System.getenv().getOrDefault(
+    "LOCALSTACK_AUTH_TOKEN", "");
 
   @Container
   protected static LocalStackContainer localStack =
     new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
     .withEnv("LOCALSTACK_HOST", "localhost.localstack.cloud")
+    .withEnv("LOCALSTACK_AUTH_TOKEN", LOCALSTACK_AUTH_TOKEN)
     .withEnv("LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT", "60")
     .withEnv("DEBUG", "1");
 


### PR DESCRIPTION
Moves LocalStack stop after Testcontainers tests, adds Docker readiness checks, and sets `DOCKER_HOST` for Maven test step